### PR TITLE
fix ES error on first install

### DIFF
--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -20,8 +20,8 @@ echo "------------------------------------------------------------"
 
 wait-for ${ARTIFAKT_ES_HOST:-elasticsearch}:${ARTIFAKT_ES_PORT:-9200} --timeout=30
 
-wait-for $APP_DATABASE_HOST:3306 --timeout=90 -- su www-data -s /bin/sh -c 'sleep 10 && cd /var/www/html/pim-community-standard && APP_ENV=dev php bin/console pim:installer:db --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal || :'
+wait-for $APP_DATABASE_HOST:3306 --timeout=90 -- su www-data -s /bin/sh -c 'sleep 10 && cd /var/www/html/pim-community-standard && APP_ENV=dev php bin/console pim:installer:db --withoutIndexes=true --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal || :'
 
-su www-data -s /bin/sh -c 'php ./bin/console pim:user:create admin password123 barracuda@artifakt.io Admin User en_US --admin -n'
+su www-data -s /bin/sh -c 'php ./bin/console pim:user:create admin password123 user@example.com Admin User en_US --admin -n'
 
 echo ">>>>>>>>>>>>>> END CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -11,7 +11,12 @@ export APP_DATABASE_USER=${ARTIFAKT_MYSQL_USER:-changeme}
 export APP_DATABASE_PASSWORD=${ARTIFAKT_MYSQL_PASSWORD:-changeme}
 export APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
 export APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
-export APP_INDEX_HOSTS='elasticsearch:9200'
+
+ES_PROTOCOL=""
+if [[ "$ARTIFAKT_ES_PORT" == "443" ]]; then
+  ES_PROTOCOL="https://"
+fi
+export APP_INDEX_HOSTS=${ES_PROTOCOL:-http://}${ARTIFAKT_ES_HOST:-elasticsearch}:${ARTIFAKT_ES_PORT:-9200}
 
 echo "------------------------------------------------------------"
 echo "The following build args are available:"


### PR DESCRIPTION
This PR fixes a weird bug on Akeneo5 where APP_INDEX_HOSTS env. var is ignored during install, but not during other commands.