### PR TITLE
run installer on first deploy only

### DIFF
--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -11,17 +11,30 @@ export APP_DATABASE_USER=${ARTIFAKT_MYSQL_USER:-changeme}
 export APP_DATABASE_PASSWORD=${ARTIFAKT_MYSQL_PASSWORD:-changeme}
 export APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
 export APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
-export APP_INDEX_HOSTS='elasticsearch:9200'
+
+ES_PROTOCOL=""
+if [[ "$ARTIFAKT_ES_PORT" == "443" ]]; then
+  ES_PROTOCOL="https://"
+fi
+export APP_INDEX_HOSTS=${ES_PROTOCOL:-http://}${ARTIFAKT_ES_HOST:-elasticsearch}:${ARTIFAKT_ES_PORT:-9200}
 
 echo "------------------------------------------------------------"
 echo "The following build args are available:"
 env
 echo "------------------------------------------------------------"
 
-wait-for-it.sh ${ARTIFAKT_ES_HOST:-elasticsearch}:${ARTIFAKT_ES_PORT:-9200} --timeout=30
+wait-for ${ARTIFAKT_ES_HOST:-elasticsearch}:${ARTIFAKT_ES_PORT:-9200} --timeout=30
 
-wait-for-it.sh $APP_DATABASE_HOST:3306 --timeout=90 -- su www-data -s /bin/sh -c 'sleep 10 && cd /var/www/html/pim-community-standard && APP_ENV=dev php bin/console pim:installer:db --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal || :'
-
-su www-data -s /bin/sh -c 'php ./bin/console pim:user:create kbeck secretp@ssw0rd kbeck@example.com Kent Beck en_US --admin -n'
+wait-for $APP_DATABASE_HOST:$ARTIFAKT_MYSQL_PORT --timeout=90 -- su www-data -s /bin/bash -c '
+  cd /var/www/html/pim-community-standard
+  ./bin/console pim:system:information 2>/dev/null;
+  if [ $? -ne 0 ]; then
+  	echo FIRST DEPLOYMENT, will run default installer
+    APP_ENV=dev php bin/console pim:installer:db --withoutIndexes=true --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal
+    php ./bin/console pim:user:create admin password123 user@example.com Admin User en_US --admin -n
+  else
+  	echo FOUND INSTALLED SYSTEM, will not run installer
+  fi
+'
 
 echo ">>>>>>>>>>>>>> END CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       PHP_CONF_OPCACHE_VALIDATE_TIMESTAMP: 1
 
   mysql:
-    image: mysql/mysql-server:8.0.22
+    image: mysql/mysql-server:8.0
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - datadir:/var/lib/mysql
@@ -54,6 +54,6 @@ services:
     image: 'google/cloud-sdk:312.0.0'
     command: 'gcloud --user-output-enabled --log-http beta emulators pubsub start --host-port=0.0.0.0:8085'
 
-volumes: 
+volumes:
   data:
   datadir:


### PR DESCRIPTION
This PR adds support for one-time only installer, even when restarting or deploying new versions of "app" container