### PR TITLE
prefer doNotDropDatabase

### DIFF
--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -26,7 +26,7 @@ wait-for $APP_DATABASE_HOST:3306 --timeout=90 -- su www-data -s /bin/bash -c '
 
   if [ $? -ne 0 ]; then
   	echo FIRST DEPLOYMENT, will run default installer
-    APP_ENV=dev php bin/console pim:installer:db --withoutIndexes=true --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal
+    APP_ENV=dev php bin/console pim:installer:db --doNotDropDatabase --withoutIndexes=true --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal
     php ./bin/console pim:user:create admin password123 user@example.com Admin User en_US --admin -n
   else
   	echo FOUND INSTALLED SYSTEM, will not run installer


### PR DESCRIPTION
This PR fixes database creation during the install stage. 

### What was the error?

Because RDS by default does not have the CREATE DATABASE privilege, it would DROP the initial database but fail on recreating again. We now skip this and just use the existing one.