### PR TITLE
--doNotDropDatabase breaks session

### DIFF
--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -35,7 +35,7 @@ wait-for $APP_DATABASE_HOST:3306 --timeout=90 -- su --preserve-environment www-d
 
   if [ $? -ne 0 ]; then
   	echo FIRST DEPLOYMENT, will run default installer
-    APP_ENV=dev php bin/console pim:installer:db --doNotDropDatabase --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal    
+    APP_ENV=dev php bin/console pim:installer:db --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal    
     php ./bin/console pim:user:create admin password123 user@example.com Admin User en_US --admin -n
   else
   	echo FOUND INSTALLED SYSTEM, will not run installer


### PR DESCRIPTION
This PR removes an option that break init. It will be important to revisit and find why it was needed in the first place.

without --doNotDropDatabase
```
Reset elasticsearch indexes
Create session table
Create configuration table
Create messenger table
Load jobs for fixtures. (data set: src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal)
```

with --doNotDropDatabase
```
Reset elasticsearch indexes
Load jobs for fixtures. (data set: src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal)
```